### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,18 +15,18 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "bluebird": "^3.0.5",
-    "ioredis": "^1.10.0",
-    "lodash": "^3.10.1",
+    "bluebird": "^3.3.0",
+    "ioredis": "^1.15.0",
+    "lodash": "^4.3.0",
     "through2": "^2.0.0"
   },
   "devDependencies": {
-    "babel-core": "^6.1.21",
-    "babel-cli": "^6.1.4",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.1.3",
-    "babel-preset-es2015": "^6.1.2",
+    "babel-cli": "^6.5.1",
+    "babel-core": "^6.5.2",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.5.2",
+    "babel-preset-es2015": "^6.5.0",
     "expect.js": "^0.3.1",
-    "mocha": "^2.3.4",
+    "mocha": "^2.4.5",
     "sinon": "^1.17.2"
   }
 }

--- a/test/all.js
+++ b/test/all.js
@@ -1,8 +1,9 @@
-const radredis = require('../src')
-const flush = require('./flushdb')
-const redisOpts = require('./redis-opts')
-const expect = require('expect.js')
-const Promise = require('bluebird')
+import radredis  from '../src'
+import flush     from './flushdb'
+import redisOpts from './redis-opts'
+import expect    from 'expect.js'
+import Promise   from 'bluebird'
+
 const schema = {
   title: 'Post',
   properties: {

--- a/test/create.js
+++ b/test/create.js
@@ -1,8 +1,8 @@
-const radredis = require('../src')
-const flush = require('./flushdb')
-const redisOpts = require('./redis-opts')
-const expect = require('expect.js')
-const sinon = require('sinon')
+import radredis  from '../src'
+import flush     from './flushdb'
+import redisOpts from './redis-opts'
+import expect    from 'expect.js'
+import sinon     from 'sinon'
 
 const schema = { title: 'Post' }
 const beforeSave = sinon.spy()

--- a/test/delete.js
+++ b/test/delete.js
@@ -1,8 +1,9 @@
-const radredis = require('../src')
-const flush = require('./flushdb')
-const redisOpts = require('./redis-opts')
-const expect = require('expect.js')
-const sinon = require('sinon')
+import radredis  from '../src'
+import flush     from './flushdb'
+import redisOpts from './redis-opts'
+import expect    from 'expect.js'
+import sinon     from 'sinon'
+
 const spy = sinon.spy()
 
 const schema = {

--- a/test/find.js
+++ b/test/find.js
@@ -1,8 +1,8 @@
-const radredis = require('../src')
-const flush = require('./flushdb')
-const redisOpts = require('./redis-opts')
-const expect = require('expect.js')
-const Promise = require('bluebird')
+import radredis  from '../src'
+import flush     from './flushdb'
+import redisOpts from './redis-opts'
+import expect    from 'expect.js'
+import Promise   from 'bluebird'
 
 describe('Radredis', function() {
   describe('.find', function(){

--- a/test/flushdb.js
+++ b/test/flushdb.js
@@ -1,7 +1,8 @@
-const Redis = require('ioredis')
-const redisOpts = require('./redis-opts')
+import Redis     from 'ioredis'
+import redisOpts from './redis-opts'
+
 const redis = new Redis(redisOpts)
 
-module.exports = function(){
+export default function() {
   return redis.flushdb()
 }

--- a/test/range.js
+++ b/test/range.js
@@ -1,8 +1,9 @@
-const radredis = require('../src')
-const flush = require('./flushdb')
-const redisOpts = require('./redis-opts')
-const expect = require('expect.js')
-const Promise = require('bluebird')
+import radredis  from '../src'
+import flush     from './flushdb'
+import redisOpts from './redis-opts'
+import expect    from 'expect.js'
+import Promise   from 'bluebird'
+
 const schema = {
   title: 'Post',
   properties: {

--- a/test/redis-opts.js
+++ b/test/redis-opts.js
@@ -1,1 +1,1 @@
-module.exports = { db: 1, keyPrefix: 'radredis:test:' }
+export default { db: 1, keyPrefix: 'radredis:test:' }

--- a/test/scan.js
+++ b/test/scan.js
@@ -1,8 +1,8 @@
-const radredis = require('../src')
-const flush = require('./flushdb')
-const redisOpts = require('./redis-opts')
-const expect = require('expect.js')
-const Promise = require('bluebird')
+import radredis  from '../src'
+import flush     from './flushdb'
+import redisOpts from './redis-opts'
+import expect    from 'expect.js'
+import Promise   from 'bluebird'
 
 const schema = {
   title: 'Post',

--- a/test/update.js
+++ b/test/update.js
@@ -1,8 +1,9 @@
-const radredis = require('../src')
-const flush = require('./flushdb')
-const redisOpts = require('./redis-opts')
-const expect = require('expect.js')
-const sinon = require('sinon')
+import radredis  from '../src'
+import flush     from './flushdb'
+import redisOpts from './redis-opts'
+import expect    from 'expect.js'
+import sinon     from 'sinon'
+
 const schema = { title: 'Post' }
 
 describe('Radredis', function() {


### PR DESCRIPTION
Noticed the deps were out of date while laying down the groundwork for radgraph. Only notable change here is that we use a `redis.pipeline()` instead of a `redis.multi()` for `findByIds()` since it isn't a true transaction, there's nothing to be gained by locking redis during execution

As a consequence, `hgetallToObjects` method is no longer needed, as ioredis itself now implements the transformation.