### PR TITLE
[WIP] Replacing MULTIs with EVALs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "radredis",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Redis Data Adapter",
   "main": "lib/index.js",
   "repository": "https://github.com/bustlelabs/radredis",
   "scripts": {
     "compile": "babel -d lib/ src/",
-    "test": "./node_modules/mocha/bin/mocha --compilers js:babel-core/register",
+    "test": "mocha --compilers js:babel-core/register",
     "prepublish": "npm run compile"
   },
   "contributors": [
@@ -21,12 +21,11 @@
     "through2": "^2.0.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.5.1",
-    "babel-core": "^6.5.2",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.5.2",
-    "babel-preset-es2015": "^6.5.0",
+    "babel-cli": "^6.6.5",
+    "babel-core": "^6.7.2",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.7.0",
+    "babel-preset-es2015": "^6.6.0",
     "expect.js": "^0.3.1",
-    "mocha": "^2.4.5",
-    "sinon": "^1.17.2"
+    "mocha": "^2.4.5"
   }
 }

--- a/src/edge.js
+++ b/src/edge.js
@@ -1,33 +1,47 @@
 import _       from 'lodash'
 import Promise from 'bluebird'
 
+import { chunkScores
+       , BuildEdge
+       } from './utils'
+
 export default function Edge(redis, schema) {
+
+  const type     = schema.name
+  const keyspace = schema.name.toLowerCase()
 
   const edge =
 
-    { _redis : redis
+    { _redis    : redis
 
-    , _type  : schema.name
-    , _from  : schema.from
-    , _to    : schema.to
+    , _keyspace : keyspace
+    , _type     : schema.name
+    , _from     : schema.from
+    , _to       : schema.to
 
     // will be populated after edge object is constructed
-    , inv    : null
+    , inv       : null
 
     // ACCESSORS
 
     , from: (from, { properties, limit = 30, offset = 0 } = {}) =>
-        null
+        redis.zrevrange(`${keyspace}:${from}`, offset, offset + limit - 1, 'WITHSCORES')
+          .then(chunkScores)
+          .map(BuildEdge(type, from))
 
     , of: from =>
-        null
+        redis.zrevrange(`${keyspace}:${from}`, 0, 1, 'WITHSCORES')
+          .then(BuildEdge(type, from))
+
+    , pos: (from, to) =>
+        redis.zscore(`${keyspace}:${from}`, to)
 
     // MUTATORS
 
-    , set: (from, to, weight) =>
+    , set: (from, to, pos) =>
         null
 
-    , move: (from, oldIndex, newIndex) =>
+    , move: (from, oldPos, newPos) =>
         null
 
     , delete: (from, to) =>
@@ -37,5 +51,7 @@ export default function Edge(redis, schema) {
         null
 
     }
+
+  return edge
 
 }

--- a/src/edge.js
+++ b/src/edge.js
@@ -1,0 +1,41 @@
+import _       from 'lodash'
+import Promise from 'bluebird'
+
+export default function Edge(redis, schema) {
+
+  const edge =
+
+    { _redis : redis
+
+    , _type  : schema.name
+    , _from  : schema.from
+    , _to    : schema.to
+
+    // will be populated after edge object is constructed
+    , inv    : null
+
+    // ACCESSORS
+
+    , from: (from, { properties, limit = 30, offset = 0 } = {}) =>
+        null
+
+    , of: from =>
+        null
+
+    // MUTATORS
+
+    , set: (from, to, weight) =>
+        null
+
+    , move: (from, oldIndex, newIndex) =>
+        null
+
+    , delete: (from, to) =>
+        null
+
+    , deleteAll: from =>
+        null
+
+    }
+
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,188 +1,44 @@
-import Redis    from 'ioredis'
-import Promise  from 'bluebird'
-import _        from 'lodash'
-import through2 from 'through2'
+import Redis from 'ioredis'
 
-const systemProps = ['id', 'created_at', 'updated_at']
+import Model from './model'
 
-export default function(schema, hooks, port, host, options){
-  const modelKeyspace = schema.title.toLowerCase()
-  const indexedAttributes = _.reduce(schema.properties, (res, val, key) => {
-    if (schema.properties[key].index === true){ res.push(key) }
-    return res
-  }, systemProps)
+import { mall
+       , mrange
+       } from './lua'
+
+export default function(port, host, options) {
 
   const redis = new Redis(port, host, options)
 
-  return {
-    _redis: redis,
-
-    all: ({ properties, limit = 30, offset = 0, index = 'id' } = {}) => {
-      return redis.zrevrange(`${modelKeyspace}:indexes:${index}`, offset, offset + limit - 1)
-      .then((ids)=>{
-        return findByIds(ids, properties)
-      })
-    },
-
-    find: (obj) => Array.isArray(obj) ? findByIds(obj) : findByIds([obj]).get(0),
-
-    range: ({ min, max, properties, limit = 30, offset = 0, index = 'id' }) => {
-      return redis.zrevrangebyscore(`${modelKeyspace}:indexes:${index}`, max, min, 'LIMIT', offset, offset + limit - 1)
-      .then((ids)=>{
-        return findByIds(ids, properties)
-      })
-    },
-
-    create: attributes => {
-      return redis.incr(`${modelKeyspace}:id`)
-      .then(function(id){
-        const now = Date.now()
-        attributes.id = id
-        attributes.created_at = now
-        attributes.updated_at = now
-        if (hooks && hooks.beforeSave) { hooks.beforeSave(attributes) }
-        return save(attributes)
-      })
-      .then(runAfterSave)
-    },
-
-    update: (id, attributes) => {
-      return findByIds([id]).get(0).then((oldAttributes)=>{
-        attributes.id = oldAttributes.id
-        attributes.created_at = oldAttributes.created_at
-        attributes.updated_at = Date.now()
-        if (hooks && hooks.beforeSave) { hooks.beforeSave(attributes, oldAttributes) }
-        return save(attributes)
-      })
-      .then(runAfterSave)
-    },
-
-    delete: id => {
-      return findByIds([id]).get(0).then(destroy)
-    },
-
-    scan: (index, props) => {
-      index = index || 'id'
-      return redis.zscanStream(`${modelKeyspace}:indexes:${index}`)
-      .pipe(through2.obj(function (keys, enc, callback) {
-        findByIds(_.map(_.chunk(keys, 2), '0'), props)
-        .map((objs) => { this.push(objs) })
-        .then(() => callback() )
-      }))
-    }
-  }
-
-  function runAfterSave(attributes) {
-    if (hooks && hooks.afterSave) {
-      return Promise.resolve(hooks.afterSave(attributes)).return(attributes)
-    } else {
-      return Promise.resolve(attributes)
-    }
-  }
-
-  function getAttributes(id, transaction, props){
-    transaction = transaction || redis
-    if (props){
-      return transaction.hmget(`${modelKeyspace}:${id}:attributes`, props)
-    } else {
-      return transaction.hgetall(`${modelKeyspace}:${id}:attributes`)
-    }
-  }
-
-  function save(attributes){
-    const transaction = redis.multi()
-    return serialize(attributes)
-    .then( serializedAttrs => transaction.hmset(`${modelKeyspace}:${attributes.id}:attributes`, serializedAttrs ))
-    .then( () => updateIndexes(attributes, indexedAttributes, transaction) )
-    .then( () => transaction.exec() )
-    .return(attributes)
-    .then(deserialize)
-  }
-
-  function destroy(attributes) {
-    const transaction = redis.multi()
-    const id = attributes.id
-
-    return Promise.map(indexedAttributes, (index) => removeFromIndex(id, index, transaction))
-      .then( () => transaction.del(`${modelKeyspace}:${id}:attributes`) )
-      .then( () => transaction.exec() )
-      .return(attributes)
-  }
-
-  function updateIndexes(attributes, indexedAttributes, transaction){
-    return Promise.resolve(indexedAttributes).map(key => {
-      if ( attributes[key] === null || typeof attributes[key] === 'undefined'){
-        return removeFromIndex(attributes.id, key, transaction)
-      } else {
-        return transaction.zadd(`${modelKeyspace}:indexes:${key}`, attributes[key], attributes.id)
+  redis.defineCommand
+    ( 'mall'
+    , { numberOfKeys: 1
+      , lua: mall
       }
-    })
-  }
+    )
 
-  function removeFromIndex(id, index, transaction) {
-    return transaction.zrem(`${modelKeyspace}:indexes:${index}`, id);
-  }
-
-  function findByIds(ids, props){
-    const transaction = redis.pipeline()
-
-    if (props) { props = systemProps.concat(props) }
-
-    return Promise.resolve(ids)
-    .map(id => getAttributes(id, transaction, props))
-    .then(() => transaction.exec() )
-    .then(resultsToObjects)
-    .map((attributes, index) => {
-      attributes.id = ids[index]
-      return attributes
-    })
-    .map(deserialize)
-
-    function resultsToObjects(results){
-      return results.map(([err, values]) => {
-        if (err) { throw err }
-        if (_.isEmpty(values)) { throw new Error ('Model not found') }
-        return props
-          ? _.zipObject(props, values)
-          : values
-      })
-    }
-  }
-
-  function deserialize(attributes){
-    attributes.id = parseInt(attributes.id, 10)
-    attributes.created_at = parseInt(attributes.created_at, 10)
-    attributes.updated_at = parseInt(attributes.updated_at, 10)
-    _.forEach(schema.properties, (value, key) => {
-      if (attributes[key] !== undefined){
-        if (value.type === 'array' || value.type === 'object'){
-          if(attributes[key]){
-            attributes[key] = JSON.parse(attributes[key])
-          } else {
-            attributes[key] = null
-          }
-        }
-        if (value.type === 'integer'){
-          attributes[key] = parseInt(attributes[key], 10)
-        }
-        if (value.type === 'boolean'){
-          if (attributes[key] === 'false'){ attributes[key] = false }
-          if (attributes[key] === 'true'){ attributes[key] = true }
-        }
-        if (value.type === 'number'){
-          attributes[key] = parseFloat(attributes[key], 10)
-        }
+  redis.defineCommand
+    ( 'mrange'
+    , { numberOfKeys: 1
+      , lua: mrange
       }
-    })
-    return attributes
-  }
-}
+    )
 
-function serialize(attributes){
-  _.forOwn(attributes, (val, key)=>{
-    if (_.isObject(val)){
-      attributes[key] = JSON.stringify(val)
+  const models = {}
+  const edges = {}
+
+  const conn =
+    { _redis: redis
+
+    // singleton constructor
+    , Model: (schema, scripts) => models[schema.title]
+        || ( models[schema.title] = Model(redis, schema, scripts) )
+
+    , Edge: schema =>
+        null
+
     }
-  })
-  return Promise.resolve(attributes)
+
+  return conn
+
 }

--- a/src/lua.js
+++ b/src/lua.js
@@ -1,0 +1,122 @@
+import _ from 'lodash'
+
+// Model scripts
+
+const idToKey = 'KEYS[1]..":"..id..":attributes"'
+
+const idsToResults = `
+local results = {}
+for i,id in ipairs(ids) do
+  table.insert(results, redis.call("HMGET", ${idToKey}, unpack(ARGV)))
+end
+`
+// props is always the first param, as tables are implemented as vectors so shifting is expensive
+
+export const mall = `
+local start = table.remove(ARGV)
+local stop  = table.remove(ARGV) + start - 1
+local index = table.remove(ARGV)
+
+local ids = redis.call("ZREVRANGE", KEYS[1]..":indexes:"..index, start, stop)
+${idsToResults}
+
+return results
+`
+
+export const mrange = `
+local max   = table.remove(ARGV)
+local min   = table.remove(ARGV)
+local start = table.remove(ARGV)
+local stop  = table.remove(ARGV) + start - 1
+local index = table.remove(ARGV)
+
+local ids = redis.call("ZREVRANGEBYSCORE", KEYS[1]..":indexes:"..index, max, min, "LIMIT", start, stop)
+${idsToResults}
+
+return results
+`
+
+// create a local keys table
+const getAttrKeys = `
+local keys = {}
+for i,v in ipairs(ARGV) do
+  if i % 2 == 1 then
+    keys[v] = i + 1
+  end
+end
+`
+
+// set an index of local id
+const setIndex = (keyspace, index) =>
+  `redis.call("ZADD", "${keyspace}:indexes:${index}", ARGV[keys["${index}"]], id)`
+
+// remove index of local id
+const remIndex = (keyspace, index) =>
+  `redis.call("ZREM", "${keyspace}:indexes:${index}", id)`
+
+// conditionally set index of a local id
+const updateIndex = (keyspace, index) =>
+  `if (ARGV[keys["${index}"]] ~= '') then ${setIndex(keyspace, index)} else ${remIndex(keyspace, index)} end `
+
+export const MCreate = (keyspace, indices, before = '', after = '') => `
+local time = table.remove(ARGV)
+local id = redis.call("INCR", KEYS[1]..":id")
+table.insert(ARGV, "id")
+table.insert(ARGV, id)
+table.insert(ARGV, "created_at")
+table.insert(ARGV, time)
+table.insert(ARGV, "updated_at")
+table.insert(ARGV, time)
+${getAttrKeys}
+${before}
+local result = redis.call("HMSET", ${idToKey}, unpack(ARGV))
+${_.reduce(indices, (r, index) => r + updateIndex(keyspace, index), '')}
+${after}
+return ARGV
+`
+
+const maybeAppendAttr = (r, p, i) => r
+  + `if not keys["${p}"] and attrs[${i+1}] then `
+  + `table.insert(ARGV, "${p}") `
+  + `table.insert(ARGV, attrs[${i+1}]) `
+  + `end
+`
+
+export const MUpdate = (keyspace, indices, props, before = '', after = '') => `
+local time = table.remove(ARGV)
+local id = table.remove(ARGV)
+table.insert(ARGV, "id")
+table.insert(ARGV, id)
+table.insert(ARGV, "updated_at")
+table.insert(ARGV, time)
+${getAttrKeys}
+local attrs = redis.call("HMGET", ${idToKey}, "${_.join(props, '","')}")
+if not attrs[1] then
+  return { err = 'Model not found' }
+end
+${_.reduce(props, maybeAppendAttr, '')}
+${before}
+local result = redis.call("HMSET", ${idToKey}, unpack(ARGV))
+${_.reduce(indices, (r, index) => r + updateIndex(keyspace, index), '')}
+${after}
+return ARGV
+`
+
+const appendAttr = (r, p, i) => r
+  + `table.insert(model, "${p}") `
+  + `table.insert(model, attrs[${i+1}]) `
+
+export const MDelete = (keyspace, indices, props) => `
+local id = table.remove(ARGV)
+local attrs = redis.call("HMGET", ${idToKey}, "${_.join(props, '","')}")
+if not attrs[1] then
+  return { err = 'Model not found' }
+end
+redis.call("DEL", ${idToKey})
+${_.reduce(indices, (r, index) => r + remIndex(keyspace, index), '')}
+local model = {}
+${_.reduce(props, appendAttr, '')}
+return model
+`
+
+// Edge scripts

--- a/src/lua.js
+++ b/src/lua.js
@@ -120,3 +120,23 @@ return model
 `
 
 // Edge scripts
+
+const eset = `
+
+`
+
+const emoveup = `
+
+`
+
+const emovedown = `
+
+`
+
+const edelete = `
+
+`
+
+const edeleteall = `
+
+`

--- a/src/model.js
+++ b/src/model.js
@@ -1,0 +1,153 @@
+import _        from 'lodash'
+import Promise  from 'bluebird'
+import through2 from 'through2'
+
+import { extractVals
+       , AttachProps
+       , splitPairs
+       , systemProps
+       , includeSystem
+       , normalizeProps
+       , serializeAttrs
+       , DeserializeAttrs
+       } from './utils'
+
+import { MCreate
+       , MUpdate
+       , MDelete
+       } from './lua'
+
+export default function Model(redis, schema, { beforeSave, afterSave } = {}) {
+
+  const keyspace = schema.title.toLowerCase()
+
+  // normalize properties
+  const props = _.assign
+    ( {}
+    , systemProps
+    , normalizeProps(schema.properties)
+    )
+
+  const propNames = _.keys(props)
+  const indices   = _.filter(propNames, k => props[k].index)
+
+  const deserialize = DeserializeAttrs(props)
+
+  // custom mutation commands
+
+  const prefix = (redis.options.keyPrefix || '') + keyspace
+
+  const create = `mcreate${keyspace}`
+  redis.defineCommand
+    ( create
+    , { numberOfKeys: 1
+      , lua: MCreate(prefix, indices, beforeSave, afterSave)
+      }
+    )
+
+  const update = `mupdate${keyspace}`
+  redis.defineCommand
+    ( update
+    , { numberOfKeys: 1
+      , lua: MUpdate(prefix, indices, propNames, beforeSave, afterSave)
+      }
+    )
+
+  const destroy = `mdelete${keyspace}`
+  redis.defineCommand
+    ( destroy
+    , { numberOfKeys: 1
+      , lua: MDelete(prefix, indices, propNames)
+      }
+    )
+
+  const model =
+
+    { _redis:    redis
+    , _keyspace: keyspace
+
+    // ACCESSORS
+
+    , find: (ids, properties = propNames) =>
+        ( properties = includeSystem(properties)
+        , Array.isArray(ids)
+
+            // ============== BEGIN CODE SMELL
+            // TODO: refactor this int a general transaction builder
+            // ideally the client should just write a promise map
+            // and never have to worry about this optimization
+            ? _.reduce
+                ( ids
+                , (p, id) =>
+                    p.hmget(`${keyspace}:${id}:attributes`, properties)
+                , redis.pipeline()
+                ).exec()
+                .map(extractVals)
+                .map(AttachProps(properties))
+                .map(deserialize)
+            // ============== END CODE SMELL
+                //
+            : redis.hmget(`${keyspace}:${ids}:attributes`, properties)
+                .then(AttachProps(properties))
+                .then(deserialize)
+
+        )
+
+    , all: ( { properties = propNames
+             , limit = 30
+             , offset = 0
+             , index = 'id'
+             } = {}
+           ) =>
+        ( properties = includeSystem(properties)
+        , redis.mall(keyspace, properties, index, limit, offset)
+            .map(AttachProps(properties))
+            .map(deserialize)
+        )
+
+    , range: ( { index = 'id'
+               , min
+               , max
+               , properties = propNames
+               , limit = 30
+               , offset = 0
+               }
+             ) =>
+        ( properties = includeSystem(properties)
+        , redis.mrange(keyspace, properties, index, limit, offset, min, max)
+            .map(AttachProps(properties))
+            .map(deserialize)
+        )
+
+    // MUTATORS
+
+    , create: attrs =>
+        redis[create](keyspace, serializeAttrs(attrs), +Date.now())
+          .then(splitPairs)
+          .then(deserialize)
+
+    , update: (id, attrs) =>
+        redis[update](keyspace, serializeAttrs(attrs), id, +Date.now())
+          .then(splitPairs)
+          .then(deserialize)
+
+    , delete: id =>
+        redis[destroy](keyspace, id)
+          .then(splitPairs)
+          .then(deserialize)
+
+    // SCAN
+
+    , scan: (index = 'id', props = propNames) =>
+        redis.zscanStream(`${keyspace}:indexes:${index}`)
+          .pipe(through2.obj(function (keys, enc, callback) {
+            model.find(_.map(_.chunk(keys, 2), '0'), props)
+              .map(objs => { this.push(objs) })
+              .then(() => callback() )
+          }))
+
+    }
+
+  return model
+
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,83 @@
+import _       from 'lodash'
+import Promise from 'bluebird'
+
+// pass redis errors as rejected promises
+export function extractVals([ err, val ]) {
+  return err
+    ? Promise.reject(err)
+    : Promise.resolve(val)
+}
+
+export function AttachProps(props) {
+  return function attachProps(vals) {
+    return Promise.resolve([vals, props])
+  }
+}
+
+// TODO: optimize
+// [ 0, 1, 2, 3, 4, 5 ] => [ [ 1, 3, 5 ], [ 0, 2, 4 ] ]
+export function splitPairs(vals) {
+  return [ _.filter(vals, (v, i) => i % 2 === 1)
+         , _.filter(vals, (v, i) => i % 2 === 0)
+         ]
+}
+
+export const systemProps =
+  { id:         { type: 'integer', index: true }
+  , created_at: { type: 'integer', index: true }
+  , updated_at: { type: 'integer', index: true }
+  }
+
+export function includeSystem(props) {
+  return _.union(props, ['id', 'created_at', 'updated_at'])
+}
+
+// normalize and allow shorthands for non-index props
+export function normalizeProps(props) {
+  return _.mapValues
+    ( props
+    , prop => ( typeof prop === "string" )
+        ? { type: prop }
+        : prop
+    )
+}
+
+export function serializeAttrs(attrs) {
+  return _(attrs)
+    .mapValues(val => _.isObject(val) ? JSON.stringify(val) : val)
+    .toPairs()
+    .flatten()
+    .value()
+}
+
+export function DeserializeAttrs(props) {
+  return function deserializeAttrs([ values, ps ]) {
+    // check for undefined models
+    if (!_.reduce(values, (r, v) => r || v, false))
+      return Promise.reject(new Error('Model not found'))
+    // zip and deserialize
+    return _(ps)
+      .zipObject(values)
+      .omitBy(_.isNull)
+      .mapValues
+        ( (v, k) => {
+            const type = props[k].type
+            if (type === 'array' || type === 'object') {
+              return JSON.parse(v)
+            }
+            if (type === 'integer') {
+              return parseInt(v, 10)
+            }
+            if (type === 'number') {
+              return parseFloat(v, 10)
+            }
+            if (type === 'boolean') {
+              if (v === 'false') return false
+              if (v === 'true' ) return true
+            }
+            return v
+          }
+        )
+      .value()
+  }
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -81,3 +81,17 @@ export function DeserializeAttrs(props) {
       .value()
   }
 }
+
+export function chunkScores(results) {
+  return _.chunk(results, 2)
+}
+
+export function BuildEdge(type, from) {
+  function (to, position) {
+    return { type
+           , from
+           , to
+           , position
+           }
+  }
+}

--- a/test/all.js
+++ b/test/all.js
@@ -11,7 +11,8 @@ const schema = {
     author_id: { type: 'integer', index: true }
   }
 }
-const Post = radredis(schema, {}, redisOpts)
+
+const Post = radredis(redisOpts).Model(schema)
 
 describe('Radredis', function() {
 
@@ -83,4 +84,4 @@ describe('Radredis', function() {
       })
     })
   })
-});
+})

--- a/test/create.js
+++ b/test/create.js
@@ -2,12 +2,9 @@ import radredis  from '../src'
 import flush     from './flushdb'
 import redisOpts from './redis-opts'
 import expect    from 'expect.js'
-import sinon     from 'sinon'
 
-const schema = { title: 'Post' }
-const beforeSave = sinon.spy()
-const afterSave = sinon.spy()
-const Post = radredis(schema, { beforeSave, afterSave }, redisOpts)
+const schema = { title: 'Post', properties: { title: 'string' } }
+const Post = radredis(redisOpts).Model(schema)
 
 describe('Radredis', function() {
   before(flush)
@@ -36,13 +33,13 @@ describe('Radredis', function() {
     it('should set a generated an id', ()=>{
       expect(post.id).to.be.a('number')
     })
-
+/*  TODO: fix these tests, before and after save are scripts not hooks now
     it('should call the beforeSave hook', function(){
       expect(beforeSave.calledOnce).to.be.ok()
     })
 
     it('should call the afterSave hook', function(){
       expect(afterSave.calledOnce).to.be.ok()
-    })
+    })*/
   })
 });

--- a/test/delete.js
+++ b/test/delete.js
@@ -2,9 +2,6 @@ import radredis  from '../src'
 import flush     from './flushdb'
 import redisOpts from './redis-opts'
 import expect    from 'expect.js'
-import sinon     from 'sinon'
-
-const spy = sinon.spy()
 
 const schema = {
   title: 'Post',
@@ -13,7 +10,7 @@ const schema = {
     author_id: { type: 'integer', index: true }
   }
 }
-const Post = radredis(schema, { beforeSave: spy }, redisOpts)
+const Post = radredis(redisOpts).Model(schema)
 
 const expectModelNotFound = [
   (result) => expect(result).to.be(undefined),

--- a/test/find.js
+++ b/test/find.js
@@ -12,7 +12,7 @@ describe('Radredis', function() {
         title: { type: 'string' }
       }
     }
-    const Post = radredis(schema, {}, redisOpts)
+    const Post = radredis(redisOpts).Model(schema)
 
     before(function(){
       return flush().then(function(){
@@ -86,7 +86,7 @@ describe('Radredis', function() {
       falseBool: false
     }
 
-    const Post = radredis(schema, {}, redisOpts)
+    const Post = radredis(redisOpts).Model(schema)
 
     before(()=>{
       return Post.create(attributes)
@@ -112,7 +112,6 @@ describe('Radredis', function() {
     })
 
     it('should return a parsed boolean', function(){
-      console.log(post)
       expect(post.trueBool).to.be(true)
       expect(post.falseBool).to.be(false)
     })

--- a/test/range.js
+++ b/test/range.js
@@ -11,7 +11,7 @@ const schema = {
     author_id: { type: 'integer', index: true }
   }
 }
-const Post = radredis(schema, {}, redisOpts)
+const Post = radredis(redisOpts).Model(schema)
 
 describe('Radredis', function() {
 

--- a/test/scan.js
+++ b/test/scan.js
@@ -11,7 +11,7 @@ const schema = {
     author_id: { type: 'integer', index: true }
   }
 }
-const Post = radredis(schema, {}, redisOpts)
+const Post = radredis(redisOpts).Model(schema)
 
 describe('Radredis', function() {
 

--- a/test/update.js
+++ b/test/update.js
@@ -2,9 +2,9 @@ import radredis  from '../src'
 import flush     from './flushdb'
 import redisOpts from './redis-opts'
 import expect    from 'expect.js'
-import sinon     from 'sinon'
 
-const schema = { title: 'Post' }
+const schema = { title: 'Post', properties: { title: 'string' } }
+const Post = radredis(redisOpts).Model(schema)
 
 describe('Radredis', function() {
   describe('.update', function(){
@@ -12,7 +12,6 @@ describe('Radredis', function() {
     describe('id does not exist', function(){
       before(flush)
 
-      const Post = radredis(schema, {}, redisOpts)
 
       it('should throw an error', ()=>{
         return Post.update(27, {})
@@ -27,7 +26,6 @@ describe('Radredis', function() {
     })
 
     describe('id exists', function(){
-      const Post = radredis(schema, {}, redisOpts)
       let post
 
       before(function(){
@@ -49,7 +47,7 @@ describe('Radredis', function() {
         expect(post.updated_at).to.not.eql(post.created_at)
       })
     })
-
+/*  TODO: restore this test, hooks are now script fragments
     describe('hooks', function(){
       it('should call the beforeSave and afterSave hooks', function(){
         const beforeSave = sinon.spy()
@@ -65,6 +63,6 @@ describe('Radredis', function() {
           expect(afterSave.calledWithMatch({ title: 'New Title'})).to.be.ok()
         })
       })
-    })
+    })*/
   })
 });


### PR DESCRIPTION
This is just an experiment, might not be worthwhile to actually merge this. This is a pretty major refactor that pushes as much of the logic into redis as possible by using LUA scripts. Models generate LUA scripts to perform the operations, and each operation becomes a redis EVAL call.

Some naive benchmarks seem to suggest this is more performant, although I need to test this further. Also, now that every command is just an atomic EVAL call, pipelining becomes trivial. Will likely implement a pipelining feature before taking off the [WIP] tag.

### Breaking Changes:
- Constructor must be called from a root connection. i.e. you must say `const DB = radredis(opts); const Model = DB.Model(schema, { beforeSave: '--', afterSave: '--' })`
- No more before/after save hooks. Instead, there are places where you can drop a before/after save LUA script to perform transformations on the server side
- No more HGETALL. Radredis now expects rigid schemas and an explicit `properties` parameter for accessor methods, defaulting to a list of all properties. `HMGET` is a constant factor more efficient, and this prevents unexpected behaviour with setting fields that shouldn't exist
- RFC: Update retrieves missing values from the existing model. In the previous implementation, update just called an HMSET and returned the serialized attributes. When attempting a partial update, this means only some of the attributes would be returned. This also makes explicit the fact that a partial update (note that undefined is not the same as null) only updates a part of the model, rather than deleting unset fields.

Notice that the new constructor is to encourage sharing a connection between models to allow pipelining. Furthermore, I'm playing around with integrating `radgraph` into the core `radredis` library becomes it seems to be a natural extension of `radredis` indices. This lends itself to encouraging code re-use, as well as providing nice features like true associations (retrieving related objects) rather than just an edge store for a graph.

All of this stuff is experimental though. This would mostly eliminate the boilerplate/wrappers on the `radql` end.

### TODO:
- refactor LUA scripts to be less ugly, performance was prioritized here but the code smells terrible
- revisit radgraph so that edges do not store data attributes, only weights. This is the main rationale behind this change. By bringing radgraph and radredis together, there's room for heavy optimizations for 1-to-many and 1-to-1 relationships, encouraging intermediate data types rather than decorator edges. This makes all of the GraphQL stuff a lot cleaner
- allow for custom ordering of edges and edge constraints (i.e. reverse chron vs chron, and limited length association lists)